### PR TITLE
Add repository settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: philoserf.github.io
+  description: "A small page on a massive Internet"
+  homepage: https://philoserf.github.io/


### PR DESCRIPTION
Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).

This config extends the base settings from `philoserf/.github` and includes repo-specific metadata and overrides.

Settings are applied automatically when the Settings app is installed and this PR is merged.